### PR TITLE
Organization membership check

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -821,7 +821,7 @@ class GitHubRepository(object):
 
         if "#org" in whitelist:
             # Whitelist all public members of the organization
-            if self.org and self.org.has_in_public_members(user):
+            if self.org and self.org.has_in_members(user):
                 return True
             # Whitelist the owner of a non-organization repository
             elif not self.org and user.login == self.get_owner():

--- a/test/unit/test_githubrepository.py
+++ b/test/unit/test_githubrepository.py
@@ -174,7 +174,7 @@ class TestGithubRepository(MoxTestBase):
         if with_org:
             self.setup_org()
         if whitelist and with_org and "#org" in whitelist:
-            self.org.has_in_public_members(user).AndReturn(True)
+            self.org.has_in_members(user).AndReturn(True)
         self.setup_repo()
 
         assert self.gh_repo.is_whitelisted(user, whitelist)
@@ -186,7 +186,7 @@ class TestGithubRepository(MoxTestBase):
         user.login = 'test'
         self.setup_org()
         if "#org" in whitelist and "#all" not in whitelist:
-            self.org.has_in_public_members(user).AndReturn(True)
+            self.org.has_in_members(user).AndReturn(True)
         self.setup_repo()
 
         assert self.gh_repo.is_whitelisted(user, whitelist)
@@ -200,7 +200,7 @@ class TestGithubRepository(MoxTestBase):
         if with_org:
             self.setup_org()
         if whitelist and with_org and "#org" in whitelist:
-            self.org.has_in_public_members(user).AndReturn(False)
+            self.org.has_in_members(user).AndReturn(False)
         self.setup_repo()
 
         assert not self.gh_repo.is_whitelisted(user, whitelist)

--- a/test/unit/test_pullrequest.py
+++ b/test/unit/test_pullrequest.py
@@ -188,7 +188,7 @@ class TestPullRequest(MoxTestBase):
         comments = []
         for is_org_user in org_users:
             user = self.mox.CreateMock(NamedUser)
-            org.has_in_public_members(user).AndReturn(is_org_user)
+            org.has_in_members(user).AndReturn(is_org_user)
             self.create_issue_comment("mock-comment-%s" % is_org_user,
                                       user=user)
             if is_org_user:
@@ -197,7 +197,7 @@ class TestPullRequest(MoxTestBase):
         self.mox.ReplayAll()
 
         def org_whitelist(x):
-            return org.has_in_public_members(x.user)
+            return org.has_in_members(x.user)
         assert self.pr.get_comments(whitelist=org_whitelist) == comments
 
     def test_create_issue_comment(self):


### PR DESCRIPTION
This change relaxes the organization check when using the `user:#org` filter so that contributions members of an organization who have not published their membership can also be whitelisted if the authenticated user is also part of the organization.

If the authenticated user is not part of the organization, then the behavior of the include filter should be identical to previously i.e. only public members will be included.

Proposed tag: `0.12.0` - although this should have minimal impact, this changes a default behavior