### PR TITLE
Push command

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -3365,6 +3365,27 @@ class MilestoneCommand(GitRepoCommand):
                 self.log.info('Closed milestone %s' % args.title)
 
 
+class PushCommand(GitRepoCommand):
+    """
+    Push a branch to a repository and its submodules.
+    """
+
+    NAME = "push"
+
+    def __init__(self, sub_parsers):
+        super(PushCommand, self).__init__(sub_parsers)
+        self.parser.add_argument(
+            'push', type=str,
+            help='Name of the branch to use to recursively push'
+            ' the merged branch to GitHub')
+
+    def __call__(self, args):
+        super(PushCommand, self).__call__(args)
+        self.login(args)
+        self.init_main_repo(args)
+        self.push(args, self.main_repo)
+
+
 class Rebase(GitRepoCommand):
     """Rebase Pull Requests opened against a specific base branch.
 

--- a/scc/git.py
+++ b/scc/git.py
@@ -821,7 +821,7 @@ class GitHubRepository(object):
 
         if "#org" in whitelist:
             # Whitelist all public members of the organization
-            if self.org and self.org.has_in_public_members(user):
+            if self.org and self.org.has_in_members(user):
                 return True
             # Whitelist the owner of a non-organization repository
             elif not self.org and user.login == self.get_owner():

--- a/scc/main.py
+++ b/scc/main.py
@@ -39,6 +39,7 @@ from git import ExternalIssues
 from git import Label
 from git import Merge
 from git import MilestoneCommand
+from git import PushCommand
 from git import Rate
 from git import Rebase
 from git import SetCommitStatus
@@ -69,6 +70,7 @@ def entry_point():
             (ExternalIssues.NAME, ExternalIssues),
             (Merge.NAME, Merge),
             (MilestoneCommand.NAME, MilestoneCommand),
+            (PushCommand.NAME, PushCommand),
             (Rate.NAME, Rate),
             (Rebase.NAME, Rebase),
             (SetCommitStatus.NAME, SetCommitStatus),

--- a/test/unit/test_githubrepository.py
+++ b/test/unit/test_githubrepository.py
@@ -174,7 +174,7 @@ class TestGithubRepository(MoxTestBase):
         if with_org:
             self.setup_org()
         if whitelist and with_org and "#org" in whitelist:
-            self.org.has_in_public_members(user).AndReturn(True)
+            self.org.has_in_members(user).AndReturn(True)
         self.setup_repo()
 
         assert self.gh_repo.is_whitelisted(user, whitelist)
@@ -186,7 +186,7 @@ class TestGithubRepository(MoxTestBase):
         user.login = 'test'
         self.setup_org()
         if "#org" in whitelist and "#all" not in whitelist:
-            self.org.has_in_public_members(user).AndReturn(True)
+            self.org.has_in_members(user).AndReturn(True)
         self.setup_repo()
 
         assert self.gh_repo.is_whitelisted(user, whitelist)
@@ -200,7 +200,7 @@ class TestGithubRepository(MoxTestBase):
         if with_org:
             self.setup_org()
         if whitelist and with_org and "#org" in whitelist:
-            self.org.has_in_public_members(user).AndReturn(False)
+            self.org.has_in_members(user).AndReturn(False)
         self.setup_repo()
 
         assert not self.gh_repo.is_whitelisted(user, whitelist)

--- a/test/unit/test_pullrequest.py
+++ b/test/unit/test_pullrequest.py
@@ -188,7 +188,7 @@ class TestPullRequest(MoxTestBase):
         comments = []
         for is_org_user in org_users:
             user = self.mox.CreateMock(NamedUser)
-            org.has_in_public_members(user).AndReturn(is_org_user)
+            org.has_in_members(user).AndReturn(is_org_user)
             self.create_issue_comment("mock-comment-%s" % is_org_user,
                                       user=user)
             if is_org_user:
@@ -197,7 +197,7 @@ class TestPullRequest(MoxTestBase):
         self.mox.ReplayAll()
 
         def org_whitelist(x):
-            return org.has_in_public_members(x.user)
+            return org.has_in_members(x.user)
         assert self.pr.get_comments(whitelist=org_whitelist) == comments
 
     def test_create_issue_comment(self):


### PR DESCRIPTION
The introduction of logic to couple components within super-builds (see https://github.com/ome/build-infra) has challenged the initial logic introduced in this repository where a single command was merging PRs, updating submodules and pushing to integration branches.

This PR introduces a standalone command allowing to push the state of a repository recursively to a remote branch. With it included, https://github.com/ome/build-infra/blob/1fff0fb33b55c69411e5fcaec472d4f0b635d122/recursive-merge#L43 and beyond could be more simply rewritten as:

```
scc merge $REPO_CONFIG $MERGE_OPTIONS -S $STATUS --update-gitmodules $BASE_BRANCH

echo "Update component versions"
foreach-set-dependencies

echo "Commit all component version changes"
git submodule foreach "git add -u"
git submodule foreach "git commit -m 'Update component versions' || true"
git add -u
git commit -m 'Update component versions' || true

echo "Push all branches"
scc push $PUSH_BRANCH
```

With the `scc push` command handling all the URL and recursive logic