### PR TITLE
Upload artifacts to PyPI only once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+---
 language: python
 
 python:
@@ -30,5 +31,6 @@ deploy:
   provider: pypi
   user: $PYPI_USER
   password: $PYPI_PASSWORD
+  skip_existing: true
   on:
     tags: true


### PR DESCRIPTION
See https://docs.travis-ci.com/user/deployment/pypi/#upload-artifacts-only-once

Proposing an immediate `0.12.1` to test the logic 