### PR TITLE
Py 3 fixes

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -90,7 +90,7 @@ def check_github_code(exception):
 
 
 def check_exception_message(exception):
-    if exception.message != "rc=128":
+    if not hasattr(exception, "message") or exception.message != "rc=128":
         raise
     return "Received rc=128"
 

--- a/scc/version.py
+++ b/scc/version.py
@@ -32,4 +32,6 @@ class Version(yaclifw.version.Version):
 
     def __call__(self, args):
         super(yaclifw.version.Version, self).__call__(args)
-        print(resource_string(__name__, 'RELEASE-VERSION').rstrip().decode('utf-8'))
+        v = resource_string(__name__, 'RELEASE-VERSION')
+        v = v.rstrip().decode('utf-8')
+        print(v)

--- a/scc/version.py
+++ b/scc/version.py
@@ -32,4 +32,4 @@ class Version(yaclifw.version.Version):
 
     def __call__(self, args):
         super(yaclifw.version.Version, self).__call__(args)
-        print(resource_string(__name__, 'RELEASE-VERSION').rstrip())
+        print(resource_string(__name__, 'RELEASE-VERSION').rstrip().decode('utf-8'))


### PR DESCRIPTION
Collection of fixes found while working with scc under python 3.

 * [x] fix `scc version` strings ("b'0.12.1')")
 * [x] `pip install --user` under virtualenv leads to failure ([build 11](https://py3-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-push/11/))
    - see: 
    - see: https://stackoverflow.com/questions/33412974/how-to-uninstall-a-package-installed-with-pip-install-user
 * [x] `exception.message` DNE ([build 12](https://py3-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-push/12/console))

See also:
 - https://github.com/ome/build-infra/pull/20 ([build 13](https://py3-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-push/13/))