### PR TITLE
Do not check status for private repositories

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -981,7 +981,8 @@ class GitHubRepository(object):
 
     def run_status_filter(self, pullrequest, filters):
 
-        if "status" not in filters or filters["status"] == "none":
+        if ("status" not in filters or filters["status"] == "none" or
+                self.repo.private is True):
             return True, None
 
         status = pullrequest.get_last_status("base")


### PR DESCRIPTION
In the case of mixed private/public repositories, we might still want to pass a single command which checks statuses on public repositories but ignores the status of privat repositorye.

Alternatively, we could refine the definition of the statuses to handle the private repositories case.