### PR TITLE
Use GitHub Pull Request reference for merging

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -1515,6 +1515,8 @@ class GitRepository(object):
     def merge(self, comment=False, commit_id="merge",
               set_commit_status=False):
         """Merge candidate pull requests and pull requests."""
+        for pull in self.origin.candidate_pulls:
+            self.call("git", "fetch", "origin", "pull/%s/head" % pull.number)
         self.dbg("## Unique users: %s", self.unique_logins())
         for key, url in list(self.get_merge_remotes().items()):
             self.call("git", "remote", "add", key, url)
@@ -1943,12 +1945,6 @@ class GitRepository(object):
         # Py3: TypeError: unhashable type: 'Repository'
         unique_repos = set()
         unique_logins = []
-        for pull in self.origin.candidate_pulls:
-            v = (pull.get_head_login(), pull.get_head_repo())
-            k = (v[0], v[1].full_name)
-            if k not in unique_repos:
-                unique_repos.add(k)
-                unique_logins.append(v)
         for remote, repo_branches in \
                 self.origin.candidate_branches.items():
             v = (remote, repo_branches[0])


### PR DESCRIPTION
Rather than fetching the forks, this fetches the remote associated with the
pull request as described in https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/checking-out-pull-requests-locally.

In the case of deleted forks, this should improve the robustness of the merge
command. It might also result in slight performance improvements as only the
relevant commits will be fetched as opposed to all the branches of the forks.

See also #219 which is a RFE using a similar strategy for the rebase command