### PR TITLE
Reduce number of organization API calls

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -766,8 +766,10 @@ class GitHubRepository(object):
             self.repo = gh.get_repo(user_name + '/' + repo_name)
             if self.repo.organization:
                 self.org = gh.get_organization(self.repo.organization.login)
+                self.org_members = [x.login for x in self.org.get_members()]
             else:
                 self.org = None
+                self.org_members = None
         except Exception:
             self.log.error("Failed to find %s/%s", user_name, repo_name)
             raise
@@ -832,7 +834,7 @@ class GitHubRepository(object):
 
         if "#org" in whitelist:
             # Whitelist all public members of the organization
-            if self.org and self.org.has_in_members(user):
+            if self.org and user.login in self.org_members:
                 return True
             # Whitelist the owner of a non-organization repository
             elif not self.org and user.login == self.get_owner():


### PR DESCRIPTION
Discovered while adding the support for the Check Suites API, our current logic makes a lot of unnecessary calls to the `Organization.has_in_members()` API to assess whether a comment has been made by a member of the organization.

This PR improves the implementation by caching the list of members when initializing the GitHub repository and reusing this list when detecting PRs. This should have no impact on the output and is mostly a performance improvement.

The easiest way to test is probably to run `scc merge --info master -vv` against an organizational repository with open PRs including comments:

- without this PR, the command output should inlude multiple GET calls to the `/orgs/<ORG>/members/<USER>` endpoint per PR
- with this PR, these should be replaced by a single top-level GET call to `/orgs/<ORG_ID>/members`  and the output of the candidate detection should be identical