### PR TITLE
Only consider GitHub actions check-suites for merging

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -994,7 +994,9 @@ class GitHubRepository(object):
                 return state not in ["error", "failure"]
             return True
 
-        check_suites = pullrequest.get_last_commit().get_check_suites()
+        # Only consider check suites created by the GitHub actions app (15368)
+        check_suites = pullrequest.get_last_commit().get_check_suites(
+            app_id=15368)
         if check_suites.totalCount > 0:
             for suite in check_suites:
                 if not check_status(suite.conclusion, filters["status"]):


### PR DESCRIPTION
See https://github.com/ome/omero-parade/pull/83#issuecomment-755209182. 

For each commit, check suites can be created by any app and it is not guaranteed all of them will fill the `conclusion` field. An example is https://api.github.com/repos/ome/omero-parade/commits/90024fdb12db958ee5ad0e750febc8ea5ddfcd9f/check-suites where the first check suite is created by the `dependabot` app  and  `conclusion` is `null`.

This updates the scc logic to only test the `conclusion` of check-suites created by the GitHub actions app, using the hardcoded app ID.

Using the `omero-parade` use-case as an example, without this PR, the dependabot PRs are all excluded with `state: None` 

```
sbesson@ls30630:omero-parade (master) $ ~/venvs/scc/bin/scc version
0.15.0
sbesson@ls30630:omero-parade (master) $ ~/venvs/scc/bin/scc merge master --info -S success-only
2021-01-06 11:04:58,352 [   scc.merge] INFO  Listing Pull Request(s) based on master
2021-01-06 11:04:58,352 [   scc.merge] INFO  Including Pull Request(s) opened by any public member of the organization
2021-01-06 11:04:58,352 [   scc.merge] INFO  Including Pull Request(s) labelled as include or dependencies
2021-01-06 11:04:58,352 [   scc.merge] INFO  Excluding Pull Request(s) labelled as exclude or breaking
2021-01-06 11:04:58,352 [   scc.merge] INFO  Excluding Pull Request(s) without successful status
2021-01-06 11:05:03,040 [   scc.merge] INFO  Repository: ome/omero-parade
2021-01-06 11:05:03,040 [   scc.merge] INFO  Excluded PRs:
2021-01-06 11:05:03,040 [   scc.merge] INFO    - PR 83 dependabot[bot] 'Bump axios from 0.18.1 to 0.21.1' (state: None)
2021-01-06 11:05:03,040 [   scc.merge] INFO    - PR 80 dependabot[bot] 'Bump elliptic from 6.4.1 to 6.5.3' (state: None)
2021-01-06 11:05:03,040 [   scc.merge] INFO    - PR 79 dependabot[bot] 'Bump lodash from 4.17.13 to 4.17.19' (state: None)
2021-01-06 11:05:03,040 [   scc.merge] INFO    - PR 39 chris-allan 'Expand all for Screens' (exclude comment)
2021-01-06 11:05:03,040 [   scc.merge] INFO  
```

With this change, all the dependabot PRs should be considered for inclusion in the merge commit

```
sbesson@ls30630:omero-parade (master) $ /opt/ome/scc/venv/bin/scc version
0.15.1.dev0
sbesson@ls30630:omero-parade (master) $ /opt/ome/scc/venv/bin/scc merge master --info -S success-only
2021-01-06 11:05:13,835 [   scc.merge] INFO  Listing Pull Request(s) based on master
2021-01-06 11:05:13,835 [   scc.merge] INFO  Including Pull Request(s) opened by any public member of the organization
2021-01-06 11:05:13,835 [   scc.merge] INFO  Including Pull Request(s) labelled as include or dependencies
2021-01-06 11:05:13,835 [   scc.merge] INFO  Excluding Pull Request(s) labelled as exclude or breaking
2021-01-06 11:05:13,835 [   scc.merge] INFO  Excluding Pull Request(s) without successful status
2021-01-06 11:05:19,683 [   scc.merge] INFO  Repository: ome/omero-parade
2021-01-06 11:05:19,683 [   scc.merge] INFO  Excluded PRs:
2021-01-06 11:05:19,683 [   scc.merge] INFO    - PR 39 chris-allan 'Expand all for Screens' (exclude comment)
2021-01-06 11:05:19,683 [   scc.merge] INFO  Candidate PRs:
2021-01-06 11:05:19,683 [   scc.merge] INFO    - PR 79 dependabot[bot] 'Bump lodash from 4.17.13 to 4.17.19'
2021-01-06 11:05:19,683 [   scc.merge] INFO    - PR 80 dependabot[bot] 'Bump elliptic from 6.4.1 to 6.5.3'
2021-01-06 11:05:19,684 [   scc.merge] INFO    - PR 83 dependabot[bot] 'Bump axios from 0.18.1 to 0.21.1'
2021-01-06 11:05:19,684 [   scc.merge] INFO  
```

/cc @will-moore 