### PR TITLE
Refactor `unsubscribed-repos` command

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -3077,34 +3077,38 @@ class GitHubIssues(GitHubCommand):
                     print("\n".join(sorted(issues)))
 
 
-class UnsubscribedRepos(GitHubCommand):
+class GitHubRepos(GitHubCommand):
     """
     Find repositories which the current user is not subscribed to
     """
 
-    NAME = "unsubscribed-repos"
+    NAME = "repos"
 
     def __init__(self, sub_parsers):
-        super(UnsubscribedRepos, self).__init__(sub_parsers)
+        super(GitHubRepos, self).__init__(sub_parsers)
 
         self.parser.add_argument(
             'orgs', nargs="+",
             help="organizations that should be checked")
+        self.parser.add_argument(
+            '--unsubscribed', action="store_true",
+            help="Filter repos that the user is subscribed to")
 
     def __call__(self, args):
-        super(UnsubscribedRepos, self).__call__(args)
+        super(GitHubRepos, self).__call__(args)
         self.login(args)
         login = self.gh.get_login()
         for org in args.orgs:
             print(org)
             org = self.gh.get_organization(org)
             for repo in org.get_repos():
-                found = False
-                for user in repo.get_subscribers():
-                    if user.login == login:
-                        found = True
-                        break
-                if not found:
+                filter = False
+                if args.unsubscribed:
+                    for user in repo.get_subscribers():
+                        if user.login == login:
+                            filter = True
+                            break
+                if not filter:
                     print("\t", repo.name)
 
 

--- a/scc/main.py
+++ b/scc/main.py
@@ -38,6 +38,7 @@ from .git import CheckPRs
 from .git import CheckStatus
 from .git import DeleteTags
 from .git import GitHubIssues
+from .git import GitHubRepos
 from .git import Label
 from .git import Merge
 from .git import MilestoneCommand
@@ -48,7 +49,6 @@ from .git import SetCommitStatus
 from .git import TagRelease
 from .git import Token
 from .git import TravisMerge
-from .git import UnsubscribedRepos
 from .git import UpdateSubmodules
 from .deploy import Deploy
 from .version import Version
@@ -70,6 +70,7 @@ def entry_point():
             (DeleteTags.NAME, DeleteTags),
             (Label.NAME, Label),
             (GitHubIssues.NAME, GitHubIssues),
+            (GitHubRepos.NAME, GitHubRepos),
             (Merge.NAME, Merge),
             (MilestoneCommand.NAME, MilestoneCommand),
             (PushCommand.NAME, PushCommand),
@@ -80,7 +81,6 @@ def entry_point():
             (TagRelease.NAME, TagRelease),
             (TravisMerge.NAME, TravisMerge),
             (Version.NAME, Version),
-            (UnsubscribedRepos.NAME, UnsubscribedRepos),
             (UpdateSubmodules.NAME, UpdateSubmodules),
             ])
     except Stop as stop:


### PR DESCRIPTION
Similar to the recent refactoring of the `issues` command, this lays the ground work to find out more about org repositories. Some (possible) examples:

 * [x] `repos --unsubscribed` (and inverse)
 * [ ] `repos --archived` (and inverse)
 * [ ] `repos --stats` (?? -- number of commits, etc.)
 * [ ] `repos --with-tag` / `--without-tag` / `--no-tags`