### PR TITLE
Fix GitHub exception constructor

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -51,8 +51,8 @@ github_loaded = True
 try:
     import github  # PyGithub
     try:
-        github.GithubException(0, "test")
-    except AttributeError:
+        from github import GithubException
+    except ImportError:
         print("Conflicting github module. Uninstall PyGithub3",
               file=sys.stderr)
         github_loaded = False

--- a/test/unit/test_internal_retries.py
+++ b/test/unit/test_internal_retries.py
@@ -111,8 +111,8 @@ class TestInternalRetries(MoxTestBase):
         self.gh_manager.login_or_token = "mock"
 
         # Define errors to test
-        self.server_error = GithubException(502, 'Server Error')
-        self.no_retry_exception = GithubException(-1, 'No retry')
+        self.server_error = GithubException(502, 'Server Error', None)
+        self.no_retry_exception = GithubException(-1, 'No retry', None)
         self.socket_timeout = socket.timeout()
         self.ssl_error = SSLError()
 


### PR DESCRIPTION
The latest release of [PyGithub 1.55](https://github.com/PyGithub/PyGithub/releases/tag/v1.55) changed the constructor of `GithubException` which is used for discriminating between the PyGithub and PyGithub3 libraries. The impact can be seen on https://merge-ci.openmicroscopy.org/jenkins/job/WEBSITE-push/316/console which was run quickly after the release but will affect all other push jobs.

This PR adjusts the check to use a simple import and catch and `ImportError`. This should make the library compatible with 1.55+ while keeping support for earlier versions.

The tests are adjusted to use the new constructor as per the expectation that the latest version of `PyGithub` will be used 

Proposing for an emergency `0.15.2` release 