### PR TITLE
Use clone_url rather than git_url when adding remotes

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -1971,7 +1971,7 @@ class GitRepository(object):
             if repo.private:
                 url = repo.ssh_url
             else:
-                url = repo.git_url
+                url = repo.clone_url
             remotes[key] = url
         return remotes
 


### PR DESCRIPTION
The unauthenticated git protocol on port 9418 is no longer supported by GitHub. See https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.