### PR TITLE
set github_version

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -4271,8 +4271,6 @@ class BumpVersionConda(GitRepoCommand):
                     # read the meta files and update the value
                     with open(fullpath) as fp:
                         data = yaml.load(fp)
-                    if self.KEY_GIT_VERSION not in data["package"]:
-                        data["package"][self.KEY_GIT_VERSION] = version
 
                     if data["source"][self.KEY_SHA] and \
                        self.KEY_SHA not in jinja2.keys():
@@ -4280,7 +4278,7 @@ class BumpVersionConda(GitRepoCommand):
                     if data["package"][self.KEY_VERSION] and \
                        self.KEY_VERSION not in jinja2.keys():
                         data["package"][self.KEY_VERSION] = version
-                    if data["package"][self.KEY_GIT_VERSION] and \
+                    if self.KEY_GIT_VERSION in data["package"] and \
                        self.KEY_GIT_VERSION not in jinja2.keys():
                         data["package"][self.KEY_GIT_VERSION] = version
 

--- a/scc/git.py
+++ b/scc/git.py
@@ -4084,7 +4084,7 @@ class BumpVersionConda(GitRepoCommand):
     SUFFIX = " %}"
     KEY_NAME = "name"
     KEY_VERSION = "version"
-    KEY_GIT_VERSION = "git_version"
+    KEY_GIT_VERSION = "github_version"
     KEY_SHA = "sha256"
     KEY_NUMBER = "number"
 

--- a/scc/git.py
+++ b/scc/git.py
@@ -4222,6 +4222,7 @@ class BumpVersionConda(GitRepoCommand):
         if repo_name is not None:
             url = url.replace("<{ name }}", repo_name)
         url = url.replace("<{ version }}", tag)
+        url = url.replace("<{ github_version }}", tag)
         file_name = '%s%s' % (tag, extension)
         sha256 = self.determine_sha256(file_name, url)
         os.remove(file_name)

--- a/scc/git.py
+++ b/scc/git.py
@@ -4271,6 +4271,9 @@ class BumpVersionConda(GitRepoCommand):
                     # read the meta files and update the value
                     with open(fullpath) as fp:
                         data = yaml.load(fp)
+                    if self.KEY_GIT_VERSION not in data["package"]:
+                        data["package"][self.KEY_GIT_VERSION] = version
+
                     if data["source"][self.KEY_SHA] and \
                        self.KEY_SHA not in jinja2.keys():
                         data["source"][self.KEY_SHA] = sha256

--- a/scc/git.py
+++ b/scc/git.py
@@ -4084,6 +4084,7 @@ class BumpVersionConda(GitRepoCommand):
     SUFFIX = " %}"
     KEY_NAME = "name"
     KEY_VERSION = "version"
+    KEY_GIT_VERSION = "git_version"
     KEY_SHA = "sha256"
     KEY_NUMBER = "number"
 
@@ -4276,6 +4277,9 @@ class BumpVersionConda(GitRepoCommand):
                     if data["package"][self.KEY_VERSION] and \
                        self.KEY_VERSION not in jinja2.keys():
                         data["package"][self.KEY_VERSION] = version
+                    if data["package"][self.KEY_GIT_VERSION] and \
+                       self.KEY_GIT_VERSION not in jinja2.keys():
+                        data["package"][self.KEY_GIT_VERSION] = version
 
                     if previous_version != version:
                         data["build"][self.KEY_NUMBER] = 0
@@ -4295,6 +4299,9 @@ class BumpVersionConda(GitRepoCommand):
                                 elif values[0] == self.KEY_SHA:
                                     new_line = line.replace(values[1],
                                                             "\"%s\"" % sha256)
+                                elif values[0] == self.KEY_GIT_VERSION:
+                                    new_line = line.replace(values[1],
+                                                            "\"%s\"" % version)
                                 print(new_line, end='')
                             else:
                                 print(line, end='')


### PR DESCRIPTION
The introduction of ``github_version`` like in https://github.com/ome/conda-bioformats2raw/blob/master/bioformats2raw/meta.yaml#L3 breaks the scheduled build preventing the automatic bump of version

